### PR TITLE
iOSダブルタップ拡大防止etc

### DIFF
--- a/index.html
+++ b/index.html
@@ -20,6 +20,25 @@
       height: 100vh;
     }
   </style>
+  <script>
+  /* 上下スクロール無効 */
+  window.addEventListener('touchmove', function(event) {
+    event.preventDefault();
+  });
+  /* ピッチインピッチアウトによる拡大縮小を禁止 */
+  document.documentElement.addEventListener('touchstart', function (e) {
+  if (e.touches.length >= 2) {e.preventDefault();}
+  }, false);
+  /* ダブルタップによる拡大を禁止 */
+  var t = 0;
+  document.documentElement.addEventListener('touchend', function (e) {
+  var now = new Date().getTime();
+  if ((now - t) < 350){
+    e.preventDefault();
+  }
+  t = now;
+  }, false);
+</script>
 </head>
 <body>
   <section class="load"></section>

--- a/index.html
+++ b/index.html
@@ -20,25 +20,6 @@
       height: 100vh;
     }
   </style>
-  <script>
-  /* 上下スクロール無効 */
-  window.addEventListener('touchmove', function(event) {
-    event.preventDefault();
-  });
-  /* ピッチインピッチアウトによる拡大縮小を禁止 */
-  document.documentElement.addEventListener('touchstart', function (e) {
-  if (e.touches.length >= 2) {e.preventDefault();}
-  }, false);
-  /* ダブルタップによる拡大を禁止 */
-  var t = 0;
-  document.documentElement.addEventListener('touchend', function (e) {
-  var now = new Date().getTime();
-  if ((now - t) < 350){
-    e.preventDefault();
-  }
-  t = now;
-  }, false);
-</script>
 </head>
 <body>
   <section class="load"></section>

--- a/src/RestrictIOS.js
+++ b/src/RestrictIOS.js
@@ -3,12 +3,12 @@ window.addEventListener('touchmove', event => {
   event.preventDefault();
 });
 /* ピッチインピッチアウトによる拡大縮小を禁止 */
-document.documentElement.addEventListener('touchstart', function (e) {
+document.documentElement.addEventListener('touchstart', (e) => {
   if (e.touches.length >= 2) {e.preventDefault();}
 }, false);
 /* ダブルタップによる拡大を禁止 */
 let t = 0;
-document.documentElement.addEventListener('touchend', function (e) {
+document.documentElement.addEventListener('touchend', (e) => {
   let now = new Date().getTime();
   if ((now - t) < 350){
     e.preventDefault();

--- a/src/RestrictIOS.js
+++ b/src/RestrictIOS.js
@@ -1,0 +1,17 @@
+/* 上下スクロール無効 */
+window.addEventListener('touchmove', function(event) {
+  event.preventDefault();
+});
+/* ピッチインピッチアウトによる拡大縮小を禁止 */
+document.documentElement.addEventListener('touchstart', function (e) {
+  if (e.touches.length >= 2) {e.preventDefault();}
+}, false);
+/* ダブルタップによる拡大を禁止 */
+var t = 0;
+document.documentElement.addEventListener('touchend', function (e) {
+  var now = new Date().getTime();
+  if ((now - t) < 350){
+    e.preventDefault();
+  }
+  t = now;
+}, false);

--- a/src/RestrictIOS.js
+++ b/src/RestrictIOS.js
@@ -1,5 +1,5 @@
 /* 上下スクロール無効 */
-window.addEventListener('touchmove', function(event) {
+window.addEventListener('touchmove', event => {
   event.preventDefault();
 });
 /* ピッチインピッチアウトによる拡大縮小を禁止 */

--- a/src/RestrictIOS.js
+++ b/src/RestrictIOS.js
@@ -7,9 +7,9 @@ document.documentElement.addEventListener('touchstart', function (e) {
   if (e.touches.length >= 2) {e.preventDefault();}
 }, false);
 /* ダブルタップによる拡大を禁止 */
-var t = 0;
+let t = 0;
 document.documentElement.addEventListener('touchend', function (e) {
-  var now = new Date().getTime();
+  let now = new Date().getTime();
   if ((now - t) < 350){
     e.preventDefault();
   }

--- a/src/main.js
+++ b/src/main.js
@@ -3,7 +3,7 @@ import Shooter from './Components/Shooter.js'
 import * as PubSub from 'pubsub-js'
 import EventType from './ValueObjects/EventType'
 import * as IndexAR from './indexAR.js'
-
+import * as RestrictIOS from './RestrictIOS.js'
 
 // sample is loaded
 setTimeout(() => {


### PR DESCRIPTION
iOS側の問題

ダブルタップ、ピンチインピンチアウト拡大縮小させない
http://iphone.f-tools.net/html5/Kakudai-Kinsi.html

表示領域がスクロールしてしまう。
https://qiita.com/noraworld/items/2834f2e6f064e6f6d41a

iOSの操作制限したのがAndroidで問題なければマージお願いいたします:bow:
